### PR TITLE
make "opened" property state match show() and hide() method calls

### DIFF
--- a/iron-collapse.html
+++ b/iron-collapse.html
@@ -134,21 +134,11 @@ and instead put a div inside and style that.
     },
 
     show: function() {
-      this.toggleClass('iron-collapse-closed', false);
-      this.updateSize('auto', false);
-      var s = this._calcSize();
-      this.updateSize('0px', false);
-      // force layout to ensure transition will go
-      this.offsetHeight;
-      this.updateSize(s, true);
+      this.opened = true;    
     },
 
     hide: function() {
-      this.toggleClass('iron-collapse-opened', false);
-      this.updateSize(this._calcSize(), false);
-      // force layout to ensure transition will go
-      this.offsetHeight;
-      this.updateSize('0px', true);
+      this.opened = false;    
     },
 
     updateSize: function(size, animated) {
@@ -171,7 +161,22 @@ and instead put a div inside and style that.
     },
 
     _openedChanged: function() {
-      this[this.opened ? 'show' : 'hide']();
+      if (this.opened) {
+        this.toggleClass('iron-collapse-closed', false);
+        this.updateSize('auto', false);
+        var s = this._calcSize();
+        this.updateSize('0px', false);
+        // force layout to ensure transition will go
+        this.offsetHeight;
+        this.updateSize(s, true);
+      }
+      else {
+        this.toggleClass('iron-collapse-opened', false);
+        this.updateSize(this._calcSize(), false);
+        // force layout to ensure transition will go
+        this.offsetHeight;
+        this.updateSize('0px', true);
+      }
       this.setAttribute('aria-expanded', this.opened ? 'true' : 'false');
 
     },


### PR DESCRIPTION
The opened property stays true after a call to hide() and stays false after a call to show(). Adding opened = false and opened = true to the hide and show functions has the side effect of calling the _openedChanged observer which would call the hide or show one more time. Putting the logic of hiding and showing in the observer avoids this problem and the hide and show methods now leave opened in a matching state. 

The documentation says "Use opened or toggle() to show/hide the content" and doesn't mention hide or show so maybe the intention was not to call these directly. This change allows show and hide to be called as well.